### PR TITLE
Featur/external history APIs

### DIFF
--- a/domo/domo_api/http_model.py
+++ b/domo/domo_api/http_model.py
@@ -78,6 +78,11 @@ class GithubAccountCheckRequest(BaseModel):
     github_link: str
 
 
+class GetGithubUpdateStatus(BaseModel):
+    status: str
+    last_update: datetime
+
+
 class ModifyUserInfoRequest(BaseModel):
     name: Optional[str] = None
     github_link: Optional[str] = None

--- a/domo/domo_api/http_model.py
+++ b/domo/domo_api/http_model.py
@@ -78,12 +78,12 @@ class GithubAccountCheckRequest(BaseModel):
     github_link: str
 
 
-class GetGithubUpdateStatus(BaseModel):
+class GetGithubUpdateStatusResponse(BaseModel):
     status: str
     last_update: datetime
 
 
-class GetAllUserStack(BaseModel):
+class GetAllUserStackResponse(BaseModel):
     count: int
     stacks: dict
 

--- a/domo/domo_api/http_model.py
+++ b/domo/domo_api/http_model.py
@@ -83,6 +83,11 @@ class GetGithubUpdateStatus(BaseModel):
     last_update: datetime
 
 
+class GetAllUserStack(BaseModel):
+    count: int
+    stacks: dict
+
+
 class ModifyUserInfoRequest(BaseModel):
     name: Optional[str] = None
     github_link: Optional[str] = None

--- a/domo/domo_api/views/external_history.py
+++ b/domo/domo_api/views/external_history.py
@@ -4,8 +4,8 @@ import requests
 from django.http import JsonResponse
 from domo_api.const import ReturnCode
 from domo_api.http_model import (
-    GetAllUserStack,
-    GetGithubUpdateStatus,
+    GetAllUserStackResponse,
+    GetGithubUpdateStatusResponse,
     GithubAccountCheckRequest,
     SimpleFailResponse,
     SimpleSuccessResponse,
@@ -89,7 +89,7 @@ class GithubUpdateStatus(APIView):
     def get(self, request):
         try:
             github_status = GithubStatus.objects.get(user=request.user)
-            response = GetGithubUpdateStatus(
+            response = GetGithubUpdateStatusResponse(
                 status=github_status.status, last_update=github_status.last_update
             )
             return JsonResponse(response.model_dump(), status=200)
@@ -142,7 +142,7 @@ class GithubStack(APIView):
         for stack in github_stacks:
             stacks[stack.language] = stack.code_amount
 
-        response = GetAllUserStack(count=github_stacks.count(), stacks=stacks)
+        response = GetAllUserStackResponse(count=github_stacks.count(), stacks=stacks)
         return JsonResponse(response.model_dump(), status=200)
 
 

--- a/domo/domo_api/views/external_history.py
+++ b/domo/domo_api/views/external_history.py
@@ -78,6 +78,7 @@ class GithubAccountCheck(APIView):
             status=200,
         )
 
+
 class GithubUpdateStatus(APIView):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
@@ -97,6 +98,7 @@ class GithubUpdateStatus(APIView):
                 ).model_dump(),
                 status=404,
             )
+
 
 class GithubStack(APIView):
     authentication_classes = [TokenAuthentication]

--- a/domo/domo_base/urls.py
+++ b/domo/domo_base/urls.py
@@ -64,6 +64,11 @@ urlpatterns = [
         name="get_github_stack",
     ),
     path(
+        "external-history/v1/github/update",
+        external_history.GithubManualUpdate.as_view(),
+        name="github_manual_update",
+    ),
+    path(
         "user/v1",
         user.Info.as_view(),
         name="user_info",

--- a/domo/domo_base/urls.py
+++ b/domo/domo_base/urls.py
@@ -54,7 +54,7 @@ urlpatterns = [
         name="github_account_check",
     ),
     path(
-        "external-history/v1/github/update",
+        "external-history/v1/github/status",
         external_history.GetGithubUpdateStatus.as_view(),
         name="get_github_update_status",
     ),

--- a/domo/domo_base/urls.py
+++ b/domo/domo_base/urls.py
@@ -55,8 +55,13 @@ urlpatterns = [
     ),
     path(
         "external-history/v1/github/status",
-        external_history.GetGithubUpdateStatus.as_view(),
+        external_history.GithubUpdateStatus.as_view(),
         name="get_github_update_status",
+    ),
+    path(
+        "external-history/v1/github/stack",
+        external_history.GithubStack.as_view(),
+        name="get_github_stack",
     ),
     path(
         "user/v1",

--- a/domo/domo_base/urls.py
+++ b/domo/domo_base/urls.py
@@ -54,6 +54,11 @@ urlpatterns = [
         name="github_account_check",
     ),
     path(
+        "external-history/v1/github/update",
+        external_history.GetGithubUpdateStatus.as_view(),
+        name="get_github_update_status",
+    ),
+    path(
         "user/v1",
         user.Info.as_view(),
         name="user_info",


### PR DESCRIPTION
다음과 같은 역할을 수행하는 API를 추가합니다.

1. github status를 조회
2. user의 모든 stack을 조회
3. user stack을 mannual로 업데이트